### PR TITLE
issue登録・編集・削除機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'actiontext'
 
 gem 'devise'
 
+gem 'net-http'
+
 gem 'materialize-sass'
 gem 'material_icons'
 # Reduces boot times through caching; required in config/boot.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,8 @@ GEM
     mini_mime (1.1.2)
     minitest (5.17.0)
     msgpack (1.6.0)
+    net-http (0.3.2)
+      uri
     net-imap (0.3.4)
       date
       net-protocol
@@ -212,6 +214,7 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
+    uri (0.12.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -249,6 +252,7 @@ DEPENDENCIES
   listen (~> 3.3)
   material_icons
   materialize-sass
+  net-http
   pg (~> 1.4)
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
@@ -267,4 +271,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.2.29
+   2.4.4

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,3 +40,8 @@
 .actions {
   margin: 20px
 }
+
+// TODO: checkboxを使った非同期検索を実装
+// .issue_statuses {
+//   margin: 10px;
+// }

--- a/app/assets/stylesheets/issues.scss
+++ b/app/assets/stylesheets/issues.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the issues controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,0 +1,51 @@
+class IssuesController < ApplicationController
+  def new
+    if !user_signed_in?
+      redirect_to new_user_session_path
+    end
+  end
+
+  def create
+    @issue = Issue.new(issue_params)
+    if @issue.save
+      redirect_to issues_path
+    else
+      redirect_to new_issue_path
+    end
+  end
+
+  def edit
+    @issue = Issue.find(params[:id])
+  end
+
+  def update
+    @issue = Issue.find(params[:id])
+    if @issue.update(issue_params)
+      redirect_to @issue
+    else
+      redirect_to edit_issue_path(issue)
+    end
+  end
+
+  def show
+    @issue = Issue.find(params[:id])
+  end
+
+  def index
+    @issues = Issue.all
+    @status = params[:status]
+  end
+
+  def destroy
+    @issue = Issue.find(params[:id])
+    if @issue.destroy
+      redirect_to issues_path
+    end
+  end
+
+  private
+
+  def issue_params
+    params.require(:issue).permit(:title, :content, :status)
+  end
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,7 +1,4 @@
 class StaticPagesController < ApplicationController
   def home
   end
-
-  def issue
-  end
 end

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -1,0 +1,2 @@
+module IssuesHelper
+end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,2 +1,4 @@
 class Issue < ApplicationRecord
+  enum status: { unstarted: 0, in_progress: 1, completed: 2}
+  validates :title, presence: true
 end

--- a/app/views/issues/edit.html.erb
+++ b/app/views/issues/edit.html.erb
@@ -1,0 +1,32 @@
+<h3 class="center-align">🔄</h3>
+
+<%= form_with(model: @issue, local: true, scope: :issue) do |form| %>
+
+  <div class="field">
+    <%= form.label :title, "タイトル" %>
+    <%= form.text_field :title %>
+
+    <%= form.label :content, "詳細（任意）" %>
+    <%= form.text_field :content %>
+
+    <%= form.label :status, "ステータス" %>
+    <div>
+      <label>
+        <%= form.radio_button :status, :unstarted %>
+        <%= content_tag :span, 'unstarted' %>
+      </label>
+      <label>
+        <%= form.radio_button :status, :in_progress %>
+        <%= content_tag :span, 'in progress' %>
+      </label>
+      <label>
+        <%= form.radio_button :status, :completed %>
+        <%= content_tag :span, 'completed' %>
+      </label>
+    </div>
+
+    <div class="actions center-align">
+      <%= form.submit "UPDATE", class: "btn" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -1,0 +1,49 @@
+<div class="center-align">
+  <h3><b>🤔</b></h3>
+  <% @issues.each do |issue| %>
+    <% if issue.completed? %>
+      <b>※Completedはすでに導入済みのissueです</b>
+    <% end %>
+  <% end %>
+</div>
+<!--TODO: checkboxを使った非同期検索を実装-->
+  <!---<form action="#">
+
+  <div class="container center-align">
+    <div class="row">
+      <label><input type="checkbox" checked="checked" /><span class="issue_statuses">Unstarted</span></label>
+      <label><input type="checkbox" checked="checked" /><span class="issue_statuses">In Progress</span></label>
+      <label><input type="checkbox" checked="checked" /><span class="issue_statuses">Completed</span></label>
+    </div>
+  </div>
+  </form>--->
+
+<div class="divider"></div>
+
+<div class="container">
+  <% if @issues.empty? %>
+    <h3 class="center-align"><b><%= "実装を待て！" %></b></h3>
+  <% end %>
+  <% @issues.each do |issue| %>
+    <h5>
+      <b>
+        <div class="blue-text"><%= "#{issue.title}" %></div>
+        <% if issue.status == "unstarted" %>
+          <span class="badge blue white-text"><%= "😐" +  issue.status.titleize %></span>
+        <% elsif issue.status == "in_progress" %>
+          <span class="badge orange white-text"><%= "😤" +  issue.status.titleize %></span>
+        <% else %>
+          <span class="badge green white-text"><%= "🤩" + issue.status.titleize %></span>
+        <% end %>
+      </b>
+    </h5>
+
+    <% if issue.content.present? %>
+      <%= link_to "詳細", issue %>
+    <% end %>
+    <% if current_user %>
+      <%= link_to "編集", edit_issue_path(issue) %>
+      <%= link_to "削除", issue, method: :delete,  data: { confirm: "本当に削除しますか？" } %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/issues/new.html.erb
+++ b/app/views/issues/new.html.erb
@@ -1,0 +1,34 @@
+<h3 class="center-align">💭</h3>
+
+<%= form_with(model: @issue, local: true, scope: :issue) do |form| %>
+
+  <div class="field">
+    <%= form.label :title, "タイトル" %>
+    <%= form.text_field :title %>
+
+    <%= form.label :content, "詳細(任意)" %>
+    <%= form.text_field :content %>
+
+    <%= form.label :status, "ステータス" %>
+    <div>
+      <label>
+        <%= form.radio_button :status, :unstarted, class: "with-gap" %>
+        <%= content_tag :span, 'unstarted' %>
+      </label>
+      <label>
+        <%= form.radio_button :status, :in_progress, class: "with-gap" %>
+        <%= content_tag :span, 'in progress' %>
+      </label>
+      <label>
+        <%= form.radio_button :status, :completed, class: "with-gap" %>
+        <%= content_tag :span, 'completed' %>
+      </label>
+    </div>
+
+    <div class="actions center-align">
+      <%= form.submit "CREATE", class: "btn" %>
+    </div>
+
+  </div>
+<% end %>
+

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,6 +1,12 @@
 <div class="center-align">
   <h3><b><%= @issue.title %></b></h3>
-  <b><%= @issue.status %></b>
+  <% if @issue.status == "unstarted" %>
+    <span class="blue white-text"><%= "😐" +  @issue.status.titleize %></span>
+  <% elsif @issue.status == "in_progress" %>
+    <span class="orange white-text"><%= "😤" +  @issue.status.titleize %></span>
+  <% else %>
+    <span class="green white-text"><%= "🤩" + @issue.status.titleize %></span>
+  <% end %>
   <% if current_user %>
     <%= link_to "編集", edit_issue_path(@issue) %>
     <%= link_to "削除", @issue, method: :delete,  data: { confirm: "本当に削除しますか？" } %>
@@ -11,3 +17,4 @@
   <div class="divider"></div>
   <p><%= @issue.content %></p>
 <% end %>
+

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,0 +1,13 @@
+<div class="center-align">
+  <h3><b><%= @issue.title %></b></h3>
+  <b><%= @issue.status %></b>
+  <% if current_user %>
+    <%= link_to "編集", edit_issue_path(@issue) %>
+    <%= link_to "削除", @issue, method: :delete,  data: { confirm: "本当に削除しますか？" } %>
+  <% end %>
+</div>
+
+<% if @issue.content.present?%>
+  <div class="divider"></div>
+  <p><%= @issue.content %></p>
+<% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,6 @@
 <ul id="dropdown1" class="dropdown-content">
-  <li><%= link_to "記事をつくる", "/articles/new" %></li>
+  <li><%= link_to "記事を作る", new_article_path %></li>
+  <li><%= link_to "issueを作る", new_issue_path %></li>
   <li class="divider"></li>
   <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
 </ul>
@@ -9,7 +10,7 @@
     <ul class="left">
       <li><%= link_to "Home", root_path %></li>
       <li><%= link_to "Articles", articles_path %></li>
-      <li><%= link_to "Issue", issue_path %>
+      <li><%= link_to "Issues", issues_path %>
       <% if user_signed_in? %>
         <li><a class="dropdown-trigger" href="#!" data-target="dropdown1"><%= current_user.name %><i class="material-icons right">arrow_drop_down</i></a></li>
       <% end %>

--- a/app/views/static_pages/issue.html.erb
+++ b/app/views/static_pages/issue.html.erb
@@ -1,4 +1,0 @@
-<div class='center-align'>
-  <h3>🤔</h3>
-  <h3><b>実装を待て！</b></h3>
-</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'static_pages#home'
-  get 'issue', to: 'static_pages#issue'
   post 'articles/new', to: 'articles#create'
   resources :articles
+  resources :issues
+  post 'issues/new', to: 'issues#create'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,12 @@
-Article.create do |s|
-  s.id    = 1
-  s.title = "TestArticle_1"
+#Article.create do |s|
+#  s.id    = 1
+#  s.title = "TestArticle_1"
+#  s.content = "buraburabura"
+#end
+
+Issue.create do |s|
+  s.id = 1
+  s.title = "いいね機能を追加する"
   s.content = "buraburabura"
+  s.status = 2
 end

--- a/test/controllers/issues_controller_test.rb
+++ b/test/controllers/issues_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class IssuesControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get issues_new_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get issues_edit_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get issues_show_url
+    assert_response :success
+  end
+
+  test "should get index" do
+    get issues_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
- issuesテーブルにはstatusカラムをenum型でもたせ、unstarted, in_progress, completedの3つの値を用意しました。
- index画面ではstatusがcompletedのissueが存在していれば、「Completedはすでに導入済みのissueです」と表示されるようにしたが、ファイル内で同じ意味のeach文を2つ書いてしまっている。あとで直したい
- issue詳細画面のstatus表示もなんか変。classからbadge消すとあんなに文字が細くなる。だけどbadge入れたらstatusが画面の右端にいってしまう。なんで？
- index画面において、checkboxを使った検索機能を追加したい